### PR TITLE
Fix typo

### DIFF
--- a/lessons/04_shader_uniform/README.md
+++ b/lessons/04_shader_uniform/README.md
@@ -48,7 +48,7 @@ JS 쪽으로부터 셰이더 프로그램으로 원하는 값을 그때그때 �
 
     ```js
     var location = gl.getUniformLocation(program, "u_color"); //u_color 변수 위치를 참조
-    gl.uniform4f(location, 0.8, 0.3, 0.8, 1.0); //해당 위치에 0.2, 0.3, 0.8, 1.0 데이터를 전달
+    gl.uniform4f(location, 0.8, 0.3, 0.8, 1.0); //해당 위치에 0.8, 0.3, 0.8, 1.0 데이터를 전달
     ```
 
     이렇게 두 줄로 셰이더의 `u_color`변수에 RAM으로부터 데이터가 전달됩니다. 참 쉽죠?

--- a/lessons/04_shader_uniform/contents.html
+++ b/lessons/04_shader_uniform/contents.html
@@ -87,7 +87,7 @@ function main() {
   // 72번 라인에서 활성화 이후에 비활성화를 하지 않았기 때문에 올바로 동작하는 것
   // gl.useProgram(null); //<--만일 이 라인에서 비활성화를 한다면 어떻게 될까? (null을 인자에 넣으면 buffer 또는 program이 비활성화됨)
   var location = gl.getUniformLocation(program, "u_color"); //u_color 변수 위치(location)를 참조
-  gl.uniform4f(location, 0.8, 0.3, 0.8, 1.0); //해당 location에 0.2, 0.3, 0.8, 1.0 데이터를 전달
+  gl.uniform4f(location, 0.8, 0.3, 0.8, 1.0); //해당 location에 0.8, 0.3, 0.8, 1.0 데이터를 전달
   
   //---Draw Call---//
   gl.drawElements(gl.TRIANGLES, 6, gl.UNSIGNED_SHORT, 0); 


### PR DESCRIPTION
Red 값이 코드가 주석과 다르게 돼있는 오타 수정하였습니다.

> http://localhost:8080/lessons/_current/contents.html(또는 http://localhost:8080/lessons/04_shader_uniform/contents.html)에 접속해 보시면 화면에 **보라색 사각형**이 나오는 것을 보실 수 있습니다.

**보라색 사각형**이므로, 주석 쪽이 틀린 수치인 것으로 판단하였습니다.